### PR TITLE
Add version to metadata (so ansible-librarian and other tools can resolve dependencies)

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,4 +12,4 @@ galaxy_info:
   categories:
     - networking
 dependencies: []
-
+version: 1.1.0


### PR DESCRIPTION
Very minor detail, but one that's important to [librarian-ansible][1].  Without explicitly specifying this, it thinks the role is version `0.0.0`.

[1]: https://github.com/bcoe/librarian-ansible