### PR TITLE
Added support for RHEL (and clones) 8 and 9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/bertvv/ansible-role-tftp.svg?branch=master)](https://travis-ci.org/bertvv/ansible-role-tftp)
 
-An Ansible role for installing a TFTP (Trivial File Transfer Protocol) server on RHEL/CentOS 7. Specifically, the responsibilities of this role are to:
+An Ansible role for installing a TFTP (Trivial File Transfer Protocol) server on RHEL (and clones) 7/8/9. Specifically, the responsibilities of this role are to:
 
 - install the necessary packages
 - manage the configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,8 @@
 - name: Include distribution specific variables
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
   tags: tftp

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -1,10 +1,11 @@
-# roles/tftp/vars/RedHat.yml
+# roles/tftp/vars/RedHat-8.yml
 # Variables specific to the RHEL distribution
 ---
 
 tftp_packages:
-  - libsemanage-python
-  - policycoreutils-python
+  - python3-libsemanage
+  - python3-policycoreutils
+  - policycoreutils-python-utils
   - tftp-server
 
 tftp_service: tftp.socket

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -1,10 +1,11 @@
-# roles/tftp/vars/RedHat.yml
+# roles/tftp/vars/RedHat-9.yml
 # Variables specific to the RHEL distribution
 ---
 
 tftp_packages:
-  - libsemanage-python
-  - policycoreutils-python
+  - python3-libsemanage
+  - python3-policycoreutils
+  - policycoreutils-python-utils
   - tftp-server
 
 tftp_service: tftp.socket


### PR DESCRIPTION
Hi,

I want to use it with RockyLinux 9 and I have added support for RHEL (and clones) 8 and 9.

If it is not a problem, I would be happy to have it integrated.

Thanks.